### PR TITLE
开错pr了。。

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ Three installation methods are provided; choose the one that best suits your nee
   - Range: `-100` to `100` | Default: `0`
 - **G:** Force to regenerate feature cache (Ignoring existed cache).
   - No value needed
-- **He:** Enable Mel spectrum loop mode.
+- **He:** Toggle Mel spectrum extension mode against `config.yaml` (`processing.loop_mode`).
+  - If `processing.loop_mode=false`, `He` enables loop mode.
+  - If `processing.loop_mode=true`, `He` switches to stretch mode.
   - No value needed
 
 _Note: The flags `B` and `V` were renamed to `Hb` and `Hv` respectively because they conflict with other UTAU flags but have different definitions._

--- a/README_zh_cn.md
+++ b/README_zh_cn.md
@@ -130,7 +130,9 @@ pc-nsf-hifigan 是传统 nsf-hifigan 的改进，支持输入与 mel 不匹配�
   - 范围: `-100` 到 `100` | 默认: `0`
 - **G:** 强制重新生成特征缓存（忽略已有缓存）。
   - 无需数值
-- **He:** 为长音启用 Mel 频谱循环模式。
+- **He:** 基于 `config.yaml`（`processing.loop_mode`）切换 Mel 频谱延长模式。
+  - 当 `processing.loop_mode=false` 时，`He` 会启用循环模式。
+  - 当 `processing.loop_mode=true` 时，`He` 会切换为拉伸模式。
   - 无需数值
 
 _注：由于 `B` 和 `V` 与其他 UTAU flags 名称冲突但定义不同，因此分别更名为 `Hb` 和 `Hv`。_

--- a/backend/resampler.py
+++ b/backend/resampler.py
@@ -201,8 +201,13 @@ class Resampler:
         logging.info(f'length_req: {length_req}')
         logging.info(f'stretch_length: {stretch_length}')
 
-        if CONFIG.loop_mode or "He" in self.flags.keys():
-            # 添加循环拼接模式
+        # `He` toggles extension strategy against config default:
+        # - loop_mode=False + no He => stretch
+        # - loop_mode=False + He    => loop
+        # - loop_mode=True  + no He => loop
+        # - loop_mode=True  + He    => stretch
+        use_loop_mode = bool(CONFIG.loop_mode) ^ ("He" in self.flags.keys())
+        if use_loop_mode:
             logging.info('Looping.')
             logging.info(
                 f'con_mel_frame: {int((con + thop_origin/2)//thop_origin)}')


### PR DESCRIPTION
## Summary
- Fix He extension behavior so it toggles against `processing.loop_mode` from `config.yaml` instead of always forcing loop.
- New behavior:
  - `loop_mode=false`: no `He` => stretch, with `He` => loop
  - `loop_mode=true`: no `He` => loop, with `He` => stretch
- Update English/Chinese README flag docs to match runtime behavior.

## Why
When users set `processing.loop_mode=true` globally, `He` previously became ineffective. This change restores `He` as a per-note override.